### PR TITLE
dialect: Mark address and deref as pure.

### DIFF
--- a/include/potato/dialect/ops.td
+++ b/include/potato/dialect/ops.td
@@ -9,7 +9,7 @@ include "mlir/Interfaces/FunctionInterfaces.td"
 include "mlir/Interfaces/SideEffectInterfaces.td"
 
 def Potato_AddressOp
-  : Potato_Op< "address", [SymbolUserOpInterface, DeclareOpInterfaceMethods<SymbolUserOpInterface>] >
+  : Potato_Op< "address", [Pure, SymbolUserOpInterface, DeclareOpInterfaceMethods<SymbolUserOpInterface>] >
   , Arguments<( ins FlatSymbolRefAttr:$symbol )>
   , Results<( outs AnyType:$ptr )>
 {
@@ -37,7 +37,7 @@ def Potato_AssignOp
 }
 
 def Potato_DereferenceOp
-  : Potato_Op< "deref" >
+  : Potato_Op< "deref", [Pure] >
   , Arguments<( ins AnyType: $ptr )>
   , Results<( outs AnyType: $val )>
 {


### PR DESCRIPTION
- Address of operation is pure, as the address of a symbol does not change and this operation always yields the same points-to set.
- Dereference of the same value will also provide the same points-to set. It does not write into any other points-to sets and as such can be safely merged into one and hoisted out of loops.